### PR TITLE
Add support for provisioning on Packet.net

### DIFF
--- a/provision/main.go
+++ b/provision/main.go
@@ -4,10 +4,11 @@ import (
 	"os"
 
 	"github.com/apprenda/kismatic-provision/provision/aws"
+	"github.com/apprenda/kismatic-provision/provision/packet"
 	"github.com/spf13/cobra"
 )
 
-var RootCmd = &cobra.Command{
+var rootCmd = &cobra.Command{
 	Use:   "provision",
 	Short: "Provision is a tool for making Kubernetes capable infrastructure",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -17,11 +18,12 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(aws.Cmd())
+	rootCmd.AddCommand(aws.Cmd())
+	rootCmd.AddCommand(packet.Cmd())
 }
 
 func main() {
-	if err := RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}
 }

--- a/provision/packet/client.go
+++ b/provision/packet/client.go
@@ -1,0 +1,204 @@
+package packet
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/packethost/packngo"
+)
+
+// OS is an operating system supported on Packet
+type OS string
+
+// Region where nodes are deployed
+type Region string
+
+const (
+	// Ubuntu1604LTS OS image
+	Ubuntu1604LTS = OS("ubuntu_16_04_image")
+	// CentOS7 OS image
+	CentOS7 = OS("centos_7_image")
+	// USEast region
+	USEast = Region("ewr1")
+	// USWest region
+	USWest = Region("sjc1")
+	// EUWest region
+	EUWest = Region("ams1")
+)
+
+// Client for managing infrastructure on Packet
+type Client struct {
+	Token     string
+	ProjectID string
+	SSHKey    string
+
+	apiClient *packngo.Client
+}
+
+// Node is a Packet.net node
+type Node struct {
+	ID          string
+	Host        string
+	PublicIPv4  string
+	PrivateIPv4 string
+	SSHUser     string
+}
+
+func newFromEnv() (*Client, error) {
+	token := os.Getenv("PACKET_AUTH_TOKEN")
+	projectID := os.Getenv("PACKET_PROJECT_ID")
+	if token == "" || projectID == "" {
+		return nil, errors.New("PACKET_AUTH_TOKEN and PACKET_PROJECT_ID are required environment variables")
+	}
+	sshKey := os.Getenv("PACKET_SSH_KEY_PATH")
+	if sshKey == "" {
+		cwd, _ := os.Getwd()
+		sshKey = filepath.Join(cwd, "kismatic-packet.pem")
+	}
+	return &Client{
+		Token:     token,
+		ProjectID: projectID,
+		SSHKey:    sshKey,
+	}, nil
+}
+
+// CreateNode creates a node in packet with the given hostname and OS
+func (c Client) CreateNode(hostname string, os OS, region Region) (string, error) {
+	device := &packngo.DeviceCreateRequest{
+		HostName:     hostname,
+		OS:           string(os),
+		Tags:         []string{"integration-test"},
+		ProjectID:    c.ProjectID,
+		Plan:         "baremetal_0",
+		BillingCycle: "hourly",
+		Facility:     string(region),
+	}
+	client := c.getAPIClient()
+	dev, _, err := client.Devices.Create(device)
+	if err != nil {
+		return "", err
+	}
+	return dev.ID, nil
+}
+
+func (c *Client) getAPIClient() *packngo.Client {
+	if c.apiClient != nil {
+		return c.apiClient
+	}
+	c.apiClient = packngo.NewClient("", c.Token, http.DefaultClient)
+	return c.apiClient
+}
+
+// DeleteNode deletes the node that matches the given ID
+func (c Client) DeleteNode(deviceID string) error {
+	client := c.getAPIClient()
+	resp, err := client.Devices.Delete(deviceID)
+	if err != nil {
+		return fmt.Errorf("failed to delete node with ID %q", deviceID)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to delete node with ID %q", deviceID)
+	}
+	return nil
+}
+
+// GetNode returns the node that matches the given ID
+func (c Client) GetNode(deviceID string) (*Node, error) {
+	client := c.getAPIClient()
+	dev, _, err := client.Devices.Get(deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get device %q: %v", deviceID, err)
+	}
+	if dev == nil {
+		return nil, fmt.Errorf("did not get a device from server")
+	}
+	node := &Node{
+		ID:          deviceID,
+		Host:        dev.Hostname,
+		PublicIPv4:  getPublicIPv4(dev),
+		PrivateIPv4: getPrivateIPv4(dev),
+		SSHUser:     "root",
+	}
+	return node, nil
+}
+
+// GetSSHAccessibleNode blocks until the node is accessible via SSH and returns the node's information.
+func (c Client) GetSSHAccessibleNode(deviceID string, timeout time.Duration, sshKey string) (*Node, error) {
+	timeoutChan := make(chan bool, 1)
+	go func() {
+		time.Sleep(timeout)
+		timeoutChan <- true
+	}()
+	// Loop until we get the node's public IP
+	var node *Node
+	var err error
+	for {
+		select {
+		case <-timeoutChan:
+			return nil, fmt.Errorf("timed out waiting for node to be accessible")
+		default:
+			node, err = c.GetNode(deviceID)
+			if err != nil {
+				continue
+			}
+		}
+		if node.PublicIPv4 != "" {
+			break
+		}
+		fmt.Print(".")
+		time.Sleep(5 * time.Second)
+	}
+	// Loop until ssh is accessible
+	for {
+		select {
+		case <-timeoutChan:
+			return nil, fmt.Errorf("timed out waiting for node to be accessible")
+		default:
+			if sshAccessible(node.PublicIPv4, sshKey, node.SSHUser) {
+				return node, nil
+			}
+		}
+		fmt.Print(".")
+		time.Sleep(10 * time.Second)
+	}
+}
+
+func getPublicIPv4(device *packngo.Device) string {
+	for _, net := range device.Network {
+		if net.Public != true || net.AddressFamily != 4 {
+			continue
+		}
+		if net.Address != "" {
+			return net.Address
+		}
+	}
+	return ""
+}
+
+func getPrivateIPv4(device *packngo.Device) string {
+	for _, net := range device.Network {
+		if net.Public == true || net.AddressFamily != 4 {
+			continue
+		}
+		if net.Address != "" {
+			return net.Address
+		}
+	}
+	return ""
+}
+
+func sshAccessible(ip string, sshKey, sshUser string) bool {
+	cmd := exec.Command("ssh")
+	cmd.Args = append(cmd.Args, "-i", sshKey)
+	cmd.Args = append(cmd.Args, "-o", "ConnectTimeout=5")
+	cmd.Args = append(cmd.Args, "-o", "BatchMode=yes")
+	cmd.Args = append(cmd.Args, "-o", "StrictHostKeyChecking=no")
+	cmd.Args = append(cmd.Args, fmt.Sprintf("%s@%s", sshUser, ip), "exit") // just call exit if we are able to connect
+	err := cmd.Run()
+	return err == nil
+}

--- a/provision/packet/client.go
+++ b/provision/packet/client.go
@@ -33,7 +33,7 @@ const (
 
 // Client for managing infrastructure on Packet
 type Client struct {
-	Token     string
+	APIKey    string
 	ProjectID string
 	SSHKey    string
 
@@ -50,10 +50,10 @@ type Node struct {
 }
 
 func newFromEnv() (*Client, error) {
-	token := os.Getenv("PACKET_AUTH_TOKEN")
+	apiKey := os.Getenv("PACKET_API_KEY")
 	projectID := os.Getenv("PACKET_PROJECT_ID")
-	if token == "" || projectID == "" {
-		return nil, errors.New("PACKET_AUTH_TOKEN and PACKET_PROJECT_ID are required environment variables")
+	if apiKey == "" || projectID == "" {
+		return nil, errors.New("PACKET_API_KEY and PACKET_PROJECT_ID are required environment variables")
 	}
 	sshKey := os.Getenv("PACKET_SSH_KEY_PATH")
 	if sshKey == "" {
@@ -61,7 +61,7 @@ func newFromEnv() (*Client, error) {
 		sshKey = filepath.Join(cwd, "kismatic-packet.pem")
 	}
 	return &Client{
-		Token:     token,
+		APIKey:    apiKey,
 		ProjectID: projectID,
 		SSHKey:    sshKey,
 	}, nil
@@ -90,7 +90,7 @@ func (c *Client) getAPIClient() *packngo.Client {
 	if c.apiClient != nil {
 		return c.apiClient
 	}
-	c.apiClient = packngo.NewClient("", c.Token, http.DefaultClient)
+	c.apiClient = packngo.NewClient("", c.APIKey, http.DefaultClient)
 	return c.apiClient
 }
 

--- a/provision/packet/client.go
+++ b/provision/packet/client.go
@@ -168,6 +168,26 @@ func (c Client) GetSSHAccessibleNode(deviceID string, timeout time.Duration, ssh
 	}
 }
 
+func (c Client) ListNodes() ([]Node, error) {
+	client := c.getAPIClient()
+	devices, _, err := client.Devices.List(c.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("error listing nodes: %v", err)
+	}
+	nodes := []Node{}
+	for _, d := range devices {
+		n := Node{
+			ID:          d.ID,
+			Host:        d.Hostname,
+			PublicIPv4:  getPublicIPv4(&d),
+			PrivateIPv4: getPrivateIPv4(&d),
+			SSHUser:     "root",
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, nil
+}
+
 func getPublicIPv4(device *packngo.Device) string {
 	for _, net := range device.Network {
 		if net.Public != true || net.AddressFamily != 4 {

--- a/provision/packet/client_test.go
+++ b/provision/packet/client_test.go
@@ -1,0 +1,34 @@
+// +build packet_integration
+
+package packet
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestClient(t *testing.T) {
+	// Create node
+	client, err := newFromEnv()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	hostname := "testNode"
+	osImage := CentOS7
+	deviceID, err := client.CreateNode(hostname, osImage, USEast)
+	if err != nil {
+		t.Errorf("failed to create node: %v", err)
+	}
+	// Block until ssh is up
+	timeout := 10 * time.Minute
+	if _, err := client.GetSSHAccessibleNode(deviceID, timeout, os.Getenv("PACKET_SSH_KEY")); err != nil {
+		t.Errorf("node did not become accessible")
+	}
+	// Delete node
+	time.Sleep(5 * time.Second)
+	if err := client.DeleteNode(deviceID); err != nil {
+		t.Errorf("node %q was not deleted. MANUALLY CLEAN UP NODE IN PACKET.NET", deviceID)
+	}
+}

--- a/provision/packet/create.go
+++ b/provision/packet/create.go
@@ -1,0 +1,206 @@
+package packet
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"regexp"
+	"strconv"
+	"text/template"
+	"time"
+
+	garbler "github.com/michaelbironneau/garbler/lib"
+	"github.com/spf13/cobra"
+)
+
+func createCmd() *cobra.Command {
+	opts := &packetOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Creates infrastructure for a new cluster.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreate(opts)
+		},
+	}
+	cmd.Flags().Uint16VarP(&opts.EtcdNodeCount, "etcdNodeCount", "e", 1, "Count of etcd nodes to produce.")
+	cmd.Flags().Uint16VarP(&opts.MasterNodeCount, "masterdNodeCount", "m", 1, "Count of master nodes to produce.")
+	cmd.Flags().Uint16VarP(&opts.WorkerNodeCount, "workerNodeCount", "w", 1, "Count of worker nodes to produce.")
+	cmd.Flags().BoolVar(&opts.CentOS, "useCentos", false, "If present, will install CentOS 7 rather than Ubuntu 16.04")
+	cmd.Flags().BoolVarP(&opts.NoPlan, "noplan", "n", false, "If present, foregoes generating a plan file in this directory referencing the newly created nodes")
+	cmd.Flags().StringVar(&opts.Region, "region", "us-east", "The region to be used for provisioning machines. One of us-east|us-west|eu-west")
+	return cmd
+}
+
+func regionFromString(region string) (Region, error) {
+	switch region {
+	case "us-east":
+		return USEast, nil
+	case "us-west":
+		return USWest, nil
+	case "eu-west":
+		return EUWest, nil
+	default:
+		return "", fmt.Errorf("unknown region: %s", region)
+	}
+}
+
+func runCreate(opts *packetOpts) error {
+	startTime := time.Now()
+	c, err := newFromEnv()
+	if err != nil {
+		return err
+	}
+
+	distro := Ubuntu1604LTS
+	if opts.CentOS {
+		distro = CentOS7
+	}
+	provTime := strconv.FormatInt(time.Now().Unix(), 10)
+	nodeNamePrefix := fmt.Sprintf("kismatic-%s-", provTime)
+	nodeIDs := struct {
+		etcd   []string
+		master []string
+		worker []string
+	}{}
+	region, err := regionFromString(opts.Region)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Provisioning nodes")
+	var i uint16
+	for i = 0; i < opts.EtcdNodeCount; i++ {
+		hostname := nodeNamePrefix + fmt.Sprintf("etcd-%d", i)
+		nodeID, err := c.CreateNode(hostname, distro, region)
+		if err != nil {
+			return err
+		}
+		nodeIDs.etcd = append(nodeIDs.etcd, nodeID)
+	}
+	for i = 0; i < opts.MasterNodeCount; i++ {
+		hostname := nodeNamePrefix + fmt.Sprintf("master-%d", i)
+		nodeID, err := c.CreateNode(hostname, distro, region)
+		if err != nil {
+			return err
+		}
+		nodeIDs.master = append(nodeIDs.master, nodeID)
+	}
+	for i = 0; i < opts.WorkerNodeCount; i++ {
+		hostname := nodeNamePrefix + fmt.Sprintf("worker-%d", i)
+		nodeID, err := c.CreateNode(hostname, distro, region)
+		if err != nil {
+			return err
+		}
+		nodeIDs.worker = append(nodeIDs.worker, nodeID)
+	}
+
+	fmt.Println("Waiting for nodes to be accessible via SSH. This takes a while...")
+	nodes := struct {
+		etcd   []Node
+		master []Node
+		worker []Node
+	}{}
+	for _, id := range nodeIDs.etcd {
+		node, err := c.GetSSHAccessibleNode(id, 15*time.Minute, c.SSHKey)
+		if err != nil {
+			return fmt.Errorf("error waiting for node to be ready")
+		}
+		nodes.etcd = append(nodes.etcd, *node)
+	}
+	for _, id := range nodeIDs.master {
+		node, err := c.GetSSHAccessibleNode(id, 15*time.Minute, c.SSHKey)
+		if err != nil {
+			return fmt.Errorf("error waiting for node to be ready")
+		}
+		nodes.master = append(nodes.master, *node)
+	}
+	for _, id := range nodeIDs.worker {
+		node, err := c.GetSSHAccessibleNode(id, 15*time.Minute, c.SSHKey)
+		if err != nil {
+			return fmt.Errorf("error waiting for node to be ready")
+		}
+		nodes.worker = append(nodes.worker, *node)
+	}
+	fmt.Println()
+	fmt.Printf("Finished provisioning nodes on Packet.net in %s\n", time.Now().Sub(startTime))
+
+	if opts.NoPlan {
+		fmt.Println("Etcd:")
+		for _, n := range nodes.etcd {
+			printNode(n)
+		}
+		fmt.Println("Master:")
+		for _, n := range nodes.master {
+			printNode(n)
+		}
+		fmt.Println("Worker:")
+		for _, n := range nodes.worker {
+			printNode(n)
+		}
+		return nil
+	}
+
+	// Write the plan file out
+	plan := plan{
+		Etcd:                nodes.etcd,
+		Master:              nodes.master,
+		Worker:              nodes.worker,
+		MasterNodeFQDN:      nodes.master[0].PublicIPv4,
+		MasterNodeShortName: nodes.master[0].PublicIPv4,
+		SSHUser:             nodes.master[0].SSHUser,
+		SSHKeyFile:          c.SSHKey,
+		AdminPassword:       generateAlphaNumericPassword(),
+	}
+	template, err := template.New("plan").Parse(overlayNetworkPlan)
+	if err != nil {
+		return err
+	}
+	f, err := makeUniqueFile(0)
+	if err := template.Execute(f, plan); err != nil {
+		return err
+	}
+	fmt.Printf("Wrote kismatic plan file to %s\n", f.Name())
+	return nil
+}
+
+func generateAlphaNumericPassword() string {
+	attempts := 0
+	for {
+		reqs := &garbler.PasswordStrengthRequirements{
+			MinimumTotalLength: 16,
+			Uppercase:          rand.Intn(6),
+			Digits:             rand.Intn(6),
+			Punctuation:        -1, // disable punctuation
+		}
+		pass, err := garbler.NewPassword(reqs)
+		if err != nil {
+			return "weakpassword"
+		}
+		// validate that the library actually returned an alphanumeric password
+		re := regexp.MustCompile("^[a-zA-Z1-9]+$")
+		if re.MatchString(pass) {
+			return pass
+		}
+		if attempts == 50 {
+			return "weakpassword"
+		}
+		attempts++
+	}
+}
+
+func makeUniqueFile(count int) (*os.File, error) {
+	filename := "kismatic-cluster"
+	if count > 0 {
+		filename = filename + "-" + strconv.Itoa(count)
+	}
+	filename = filename + ".yaml"
+
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return os.Create(filename)
+	}
+	return makeUniqueFile(count + 1)
+}
+
+func printNode(n Node) {
+	fmt.Printf("  %v (Public: %v, Private: %v)\n", n.Host, n.PublicIPv4, n.PrivateIPv4)
+}

--- a/provision/packet/create.go
+++ b/provision/packet/create.go
@@ -18,6 +18,11 @@ func createCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates infrastructure for a new cluster.",
+		Example: `# Create 3 etcd nodes, 2 master nodes and 3 worker nodes
+provision packet create -e 3 -m 2 -w 3
+
+# Create 1 etcd node, 1 master node and 1 worker node using CentOS 7
+provision packet create --useCentos`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreate(opts)
 		},

--- a/provision/packet/create.go
+++ b/provision/packet/create.go
@@ -56,7 +56,7 @@ func runCreate(opts *packetOpts) error {
 		distro = CentOS7
 	}
 	provTime := strconv.FormatInt(time.Now().Unix(), 10)
-	nodeNamePrefix := fmt.Sprintf("kismatic-%s-", provTime)
+	generateHostname := hostnameGenerator("kismatic", provTime)
 	nodeIDs := struct {
 		etcd   []string
 		master []string
@@ -70,7 +70,7 @@ func runCreate(opts *packetOpts) error {
 	fmt.Println("Provisioning nodes")
 	var i uint16
 	for i = 0; i < opts.EtcdNodeCount; i++ {
-		hostname := nodeNamePrefix + fmt.Sprintf("etcd-%d", i)
+		hostname := generateHostname("etcd", int(i))
 		nodeID, err := c.CreateNode(hostname, distro, region)
 		if err != nil {
 			return err
@@ -78,7 +78,7 @@ func runCreate(opts *packetOpts) error {
 		nodeIDs.etcd = append(nodeIDs.etcd, nodeID)
 	}
 	for i = 0; i < opts.MasterNodeCount; i++ {
-		hostname := nodeNamePrefix + fmt.Sprintf("master-%d", i)
+		hostname := generateHostname("master", int(i))
 		nodeID, err := c.CreateNode(hostname, distro, region)
 		if err != nil {
 			return err
@@ -86,7 +86,7 @@ func runCreate(opts *packetOpts) error {
 		nodeIDs.master = append(nodeIDs.master, nodeID)
 	}
 	for i = 0; i < opts.WorkerNodeCount; i++ {
-		hostname := nodeNamePrefix + fmt.Sprintf("worker-%d", i)
+		hostname := generateHostname("worker", int(i))
 		nodeID, err := c.CreateNode(hostname, distro, region)
 		if err != nil {
 			return err
@@ -203,4 +203,10 @@ func makeUniqueFile(count int) (*os.File, error) {
 
 func printNode(n Node) {
 	fmt.Printf("  %v (Public: %v, Private: %v)\n", n.Host, n.PublicIPv4, n.PrivateIPv4)
+}
+
+func hostnameGenerator(nodePrefix, timestamp string) func(string, int) string {
+	return func(nodeType string, nodeIndex int) string {
+		return fmt.Sprintf("%s-%s-%d-%s", nodePrefix, nodeType, nodeIndex, timestamp)
+	}
 }

--- a/provision/packet/create_minikube.go
+++ b/provision/packet/create_minikube.go
@@ -1,0 +1,88 @@
+package packet
+
+import (
+	"fmt"
+	"html/template"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func createMinikubeCmd() *cobra.Command {
+	opts := &packetOpts{}
+	cmd := &cobra.Command{
+		Use:   "create-minikube",
+		Short: "Creates infrastructure for a single node cluster.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreateMinikube(opts)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.CentOS, "useCentos", false, "If present, will install CentOS 7 rather than Ubuntu 16.04")
+	cmd.Flags().BoolVarP(&opts.NoPlan, "noplan", "n", false, "If present, foregoes generating a plan file in this directory referencing the newly created nodes")
+	cmd.Flags().StringVar(&opts.Region, "region", "us-east", "The region to be used for provisioning machines. One of us-east|us-west|eu-west")
+	return cmd
+}
+
+func runCreateMinikube(opts *packetOpts) error {
+	startTime := time.Now()
+	c, err := newFromEnv()
+	if err != nil {
+		return err
+	}
+
+	distro := Ubuntu1604LTS
+	if opts.CentOS {
+		distro = CentOS7
+	}
+	provTime := strconv.FormatInt(time.Now().Unix(), 10)
+	nodeNamePrefix := fmt.Sprintf("kismatic-%s-", provTime)
+	region, err := regionFromString(opts.Region)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Provisioning node")
+	hostname := nodeNamePrefix + fmt.Sprintf("node")
+	nodeID, err := c.CreateNode(hostname, distro, region)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Waiting for node to be accessible via SSH. This takes a while...")
+	node, err := c.GetSSHAccessibleNode(nodeID, 15*time.Minute, c.SSHKey)
+	if err != nil {
+		return fmt.Errorf("error waiting for node to be ready")
+	}
+
+	fmt.Println()
+	fmt.Printf("Finished provisioning nodes on Packet.net in %s\n", time.Now().Sub(startTime))
+
+	if opts.NoPlan {
+		fmt.Println("")
+		fmt.Printf("%+v", node)
+		return nil
+	}
+
+	// Write the plan file out
+	plan := plan{
+		Etcd:                []Node{*node},
+		Master:              []Node{*node},
+		Worker:              []Node{*node},
+		MasterNodeFQDN:      node.PublicIPv4,
+		MasterNodeShortName: node.PublicIPv4,
+		SSHUser:             node.SSHUser,
+		SSHKeyFile:          c.SSHKey,
+		AdminPassword:       generateAlphaNumericPassword(),
+	}
+	template, err := template.New("plan").Parse(overlayNetworkPlan)
+	if err != nil {
+		return err
+	}
+	f, err := makeUniqueFile(0)
+	if err := template.Execute(f, plan); err != nil {
+		return err
+	}
+	fmt.Printf("Wrote kismatic plan file to %s\n", f.Name())
+	return nil
+}

--- a/provision/packet/create_minikube.go
+++ b/provision/packet/create_minikube.go
@@ -36,14 +36,13 @@ func runCreateMinikube(opts *packetOpts) error {
 		distro = CentOS7
 	}
 	provTime := strconv.FormatInt(time.Now().Unix(), 10)
-	nodeNamePrefix := fmt.Sprintf("kismatic-%s-", provTime)
 	region, err := regionFromString(opts.Region)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Provisioning node")
-	hostname := nodeNamePrefix + fmt.Sprintf("node")
+	hostname := fmt.Sprintf("kismatic-node-%s", provTime)
 	nodeID, err := c.CreateNode(hostname, distro, region)
 	if err != nil {
 		return err

--- a/provision/packet/delete.go
+++ b/provision/packet/delete.go
@@ -1,8 +1,56 @@
 package packet
 
-import "github.com/spf13/cobra"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 func deleteCmd() *cobra.Command {
-	cmd := &cobra.Command{}
+	var deleteAll bool
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete machines from the Packet.net project. This will destroy machines. Be ready.",
+		Long: `Delete machines from the Packet.net project.
+
+This command destroys machines on the project that is being managed with this tool.
+
+It will destroy machines in the project, regardless of whether the machines were provisioned with this tool.
+
+Be ready.
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return doDelete(cmd, args, deleteAll)
+		},
+	}
+	cmd.Flags().BoolVar(&deleteAll, "all", false, "Delete all machines in the project.")
 	return cmd
+}
+
+func doDelete(cmd *cobra.Command, args []string, deleteAll bool) error {
+	if !deleteAll && len(args) != 1 {
+		return errors.New("You must provide the hostname of the machine to be deleted, or use the --all flag to destroy all machines in the project")
+	}
+	hostname := ""
+	if !deleteAll {
+		hostname = args[0]
+	}
+	client, err := newFromEnv()
+	if err != nil {
+		return err
+	}
+	nodes, err := client.ListNodes()
+	if err != nil {
+		return err
+	}
+	for _, n := range nodes {
+		if hostname == n.Host || deleteAll {
+			if err := client.DeleteNode(n.ID); err != nil {
+				return err
+			}
+			fmt.Println("Deleted", n.Host)
+		}
+	}
+	return nil
 }

--- a/provision/packet/delete.go
+++ b/provision/packet/delete.go
@@ -1,0 +1,8 @@
+package packet
+
+import "github.com/spf13/cobra"
+
+func deleteCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	return cmd
+}

--- a/provision/packet/delete.go
+++ b/provision/packet/delete.go
@@ -10,7 +10,7 @@ import (
 func deleteCmd() *cobra.Command {
 	var deleteAll bool
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [HOSTNAME]",
 		Short: "Delete machines from the Packet.net project. This will destroy machines. Be ready.",
 		Long: `Delete machines from the Packet.net project.
 
@@ -20,6 +20,11 @@ It will destroy machines in the project, regardless of whether the machines were
 
 Be ready.
 		`,
+		Example: `# Delete a specific machine in the project
+provision packet delete kismatic-master-0
+
+# Delete all machines in the project
+provision packet delete --all`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doDelete(cmd, args, deleteAll)
 		},

--- a/provision/packet/list.go
+++ b/provision/packet/list.go
@@ -1,0 +1,40 @@
+package packet
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func listCmd() *cobra.Command {
+	var quiet bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Lists infrastructure running on Packet.net",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(quiet)
+		},
+	}
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only display hostnames")
+	return cmd
+}
+
+func runList(quiet bool) error {
+	client, err := newFromEnv()
+	if err != nil {
+		return err
+	}
+	nodes, err := client.ListNodes()
+	if err != nil {
+		return err
+	}
+	if quiet {
+		for _, n := range nodes {
+			fmt.Println(n.Host)
+		}
+		return nil
+	}
+	printNodes(os.Stdout, nodes)
+	return nil
+}

--- a/provision/packet/packet.go
+++ b/provision/packet/packet.go
@@ -33,5 +33,6 @@ Optional:
 	cmd.AddCommand(createCmd())
 	cmd.AddCommand(createMinikubeCmd())
 	cmd.AddCommand(deleteCmd())
+	cmd.AddCommand(listCmd())
 	return cmd
 }

--- a/provision/packet/packet.go
+++ b/provision/packet/packet.go
@@ -1,0 +1,24 @@
+package packet
+
+import "github.com/spf13/cobra"
+
+type packetOpts struct {
+	EtcdNodeCount   uint16
+	MasterNodeCount uint16
+	WorkerNodeCount uint16
+	CentOS          bool
+	NoPlan          bool
+	Region          string
+}
+
+// Cmd returns the command for managing Packet infrastructure
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "packet",
+		Short: "Provision infrastructure on Packet.net",
+	}
+	cmd.AddCommand(createCmd())
+	cmd.AddCommand(createMinikubeCmd())
+	cmd.AddCommand(deleteCmd())
+	return cmd
+}

--- a/provision/packet/packet.go
+++ b/provision/packet/packet.go
@@ -16,6 +16,19 @@ func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "packet",
 		Short: "Provision infrastructure on Packet.net",
+		Long: `Provision infrastructure on Packet.net.
+
+The following environment variables are used when provisioning on Packet:
+Required:
+  PACKET_API_KEY: Your Packet.net API key, required for all operations
+  PACKET_PROJECT_ID: The ID of the project where machines will be provisioned
+
+Optional:
+  PACKET_SSH_KEY_PATH: The path to the SSH key to be used for accessing the machines.
+    If empty, a file called "kismatic-packet.pem" in the current working directory is
+    used as the SSH key.
+
+`,
 	}
 	cmd.AddCommand(createCmd())
 	cmd.AddCommand(createMinikubeCmd())

--- a/provision/packet/plan.go
+++ b/provision/packet/plan.go
@@ -1,0 +1,55 @@
+package packet
+
+type plan struct {
+	Etcd                []Node
+	Master              []Node
+	Worker              []Node
+	MasterNodeFQDN      string
+	MasterNodeShortName string
+	SSHUser             string
+	SSHKeyFile          string
+	AdminPassword       string
+}
+
+const overlayNetworkPlan = `cluster:
+  name: kubernetes
+  admin_password: {{.AdminPassword}}      # This password is used to login to the Kubernetes Dashboard and can also be used for administration without a security certificate
+  allow_package_installation: true      # When false, installation will not occur if any node is missing the correct deb/rpm packages. When true, the installer will attempt to install missing packages for you.
+  networking:
+    type: overlay                        # overlay or routed. Routed pods can be addressed from outside the Kubernetes cluster; Overlay pods can only address each other.
+    pod_cidr_block: 172.16.0.0/16        # Kubernetes will assign pods IPs in this range. Do not use a range that is already in use on your local network!
+    service_cidr_block: 172.17.0.0/16    # Kubernetes will assign services IPs in this range. Do not use a range that is already in use by your local network or pod network!
+    policy_enabled: false                # When true, enables network policy enforcement on the Kubernetes Pod network. This is an advanced feature.
+    update_hosts_files: true            # When true, the installer will add entries for all nodes to other nodes' hosts files. Use when you don't have access to DNS.
+  certificates:
+    expiry: 17520h                       # Self-signed certificate expiration period in hours; default is 2 years.
+  ssh:
+    user: {{.SSHUser}}
+    ssh_key: {{.SSHKeyFile}}             # Absolute path to the ssh public key we should use to manage nodes.
+    ssh_port: 22
+docker_registry:                         # Here you will provide the details of your Docker registry or setup an internal one to run in the cluster. This is optional and the cluster will always have access to the Docker Hub.
+  setup_internal: true                  # When true, a Docker Registry will be installed on top of your cluster and used to host Docker images needed for its installation.
+  address: ""                            # IP or hostname for your Docker registry. An internal registry will NOT be setup when this field is provided. Must be accessible from all the nodes in the cluster.
+  port: 443                              # Port for your Docker registry.
+  CA: ""                                 # Absolute path to the CA that was used when starting your Docker registry. The docker daemons on all nodes in the cluster will be configured with this CA.
+etcd:
+  expected_count: {{len .Etcd}}
+  nodes:{{range .Etcd}}
+  - host: {{.Host}}
+    ip: {{.PublicIPv4}}
+    internalip: {{.PrivateIPv4}}{{end}}
+master:
+  expected_count: {{len .Master}}
+  nodes:{{range .Master}}
+  - host: {{.Host}}
+    ip: {{.PublicIPv4}}
+    internalip: {{.PrivateIPv4}}{{end}}
+  load_balanced_fqdn: {{.MasterNodeFQDN}}
+  load_balanced_short_name: {{.MasterNodeShortName}}
+worker:
+  expected_count: {{len .Worker}}
+  nodes:{{range .Worker}}
+  - host: {{.Host}}
+    ip: {{.PublicIPv4}}
+    internalip: {{.PrivateIPv4}}{{end}}
+`

--- a/provision/packet/print.go
+++ b/provision/packet/print.go
@@ -1,0 +1,16 @@
+package packet
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+)
+
+func printNodes(out io.Writer, nodes []Node) {
+	tw := tabwriter.NewWriter(out, 10, 4, 3, ' ', 0)
+	fmt.Fprint(tw, "HOSTNAME\tPUBLIC IP\tPRIVATE IP\n")
+	for _, n := range nodes {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", n.Host, n.PublicIPv4, n.PrivateIPv4)
+	}
+	tw.Flush()
+}


### PR DESCRIPTION
This PR adds support for provisioning machines on packet.net. The following commands are added:
```
  create          Creates infrastructure for a new cluster.
  create-minikube Creates infrastructure for a single node cluster.
  delete          Delete machines from the Packet.net project. This will destroy machines. Be ready.
  list            Lists infrastructure running on Packet.net
```
The `delete` verb can delete machines one at a time by hostname, OR it can destroy all the machines in the project when using the `--all` flag.

Fixes #2 