### PR TITLE
Don't print new line when waiting for SSH

### DIFF
--- a/provision/aws/ssh.go
+++ b/provision/aws/ssh.go
@@ -97,7 +97,6 @@ func BlockUntilSSHOpen(publicIP, sshUser, sshKey string) {
 		cmd.Args = append(cmd.Args, fmt.Sprintf("%s@%s", sshUser, publicIP), "exit") // just call exit if we are able to connect
 		if err := cmd.Run(); err == nil {
 			// command succeeded
-			fmt.Println()
 			return
 		}
 		fmt.Printf(".")


### PR DESCRIPTION
When provisioning a large number of machines, the new lines that we print here moves stdout of the terminal screen.