### PR TITLE
Basic vagrant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Quickly build Kubernetes development, test and demo clusters on AWS and [Packet]
 
 [Linux & Packet] (docs/linuxpacket.md)
 
+[Mac & Vagrant] (docs/macvagrant.md)
+
 # Download
 
 Extract to the same location as kismatic.

--- a/docs/macvagrant.md
+++ b/docs/macvagrant.md
@@ -1,0 +1,21 @@
+# Using Mac and Vagrant
+
+## One-time Envionment Setup
+
+1. Install a Vagrant compatible virtual-machine provider such as [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+2. Install (Vagrant)[https://www.vagrantup.com/docs/installation/]
+3. Open a Terminal session
+4. <table><tr><td>`mkdir ~/kismatic` <br/>
+   `cd ~/kismatic`</td> 
+   <td>*Make a new directory for Kismatic (~/kismatic would work) and make it the working directory*</td></tr></table>
+5. <table><tr><td>`wget -O - https://kismatic-installer.s3-accelerate.amazonaws.com/latest-darwin/kismatic.tar.gz | tar -zx`</td> 
+   <td> *Download & unpack Kismatic*</td></tr></table>
+
+## Make a new cluster
+
+6. <table><tr><td>`./provision vagrant create-mini`</td><td> *create a single virtual machinen instance kubernetes cluster.*</td></tr></table>
+7. <table><tr><td>`./kismatic install apply -f kismatic-cluster.yaml`</td><td> *install Kubernetes*</td></tr></table>
+
+## Tear it down when you're done with it
+
+8. <table><tr><td>`vagrant destroy --force`</td><td> *remove any VM instances created by kismatic on this machine.*</td></tr></table>

--- a/provision/main.go
+++ b/provision/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/apprenda/kismatic-provision/provision/aws"
 	"github.com/apprenda/kismatic-provision/provision/packet"
+	"github.com/apprenda/kismatic-provision/provision/vagrant"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(aws.Cmd())
 	rootCmd.AddCommand(packet.Cmd())
+	rootCmd.AddCommand(vagrant.Cmd())
 }
 
 func main() {

--- a/provision/utils/utils.go
+++ b/provision/utils/utils.go
@@ -1,0 +1,204 @@
+package utils
+
+import (
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	garbler "github.com/michaelbironneau/garbler/lib"
+	"golang.org/x/crypto/ssh"
+)
+
+func MakeFileAskOnOverwrite(name string) (*os.File, error) {
+	if _, err := os.Stat(name); os.IsNotExist(err) {
+		return os.Create(name)
+	} else {
+		prompt := fmt.Sprintf("Existing file with name %v, Overwrite?", name)
+		if AskForConfirmation(prompt) {
+			truncateErr := os.Truncate(name, 0)
+			if truncateErr != nil {
+				return nil, truncateErr
+			}
+
+			return os.OpenFile(name, os.O_APPEND|os.O_WRONLY, 0666)
+		} else {
+			return nil, errors.New(fmt.Sprintf("existing file %v cannot be overwritten", name))
+		}
+	}
+}
+
+func AskForConfirmation(prompt string) bool {
+	fmt.Printf("%v  (y/N):", prompt)
+
+	var response string
+	_, err := fmt.Scanln(&response)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	okayResponseSet := MakeStringSet([]string{"y", "yes"})
+	response = strings.ToLower(response)
+
+	if len(response) == 0 {
+		return false
+	} else if StringSetContains(okayResponseSet, response) {
+		return true
+	} else {
+		return AskForConfirmation(prompt)
+	}
+}
+
+func StringSetContains(set map[string]struct{}, value string) bool {
+	_, ok := set[value]
+	return ok
+}
+
+func MakeStringSet(slice []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(slice))
+	for _, s := range slice {
+		set[s] = struct{}{}
+	}
+	return set
+}
+
+func MakeUniqueFile(name string, suffix string, count int) (*os.File, error) {
+	var filename string
+
+	if count > 0 {
+		filename = name + "-" + strconv.Itoa(count)
+	} else {
+		filename = name
+	}
+
+	filename = filename + suffix
+
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return os.Create(filename)
+	} else {
+		return MakeUniqueFile(name, suffix, count+1)
+	}
+}
+
+func GenerateAlphaNumericPassword() string {
+	attempts := 0
+	for {
+		reqs := &garbler.PasswordStrengthRequirements{
+			MinimumTotalLength: 16,
+			Uppercase:          rand.Intn(6),
+			Digits:             rand.Intn(6),
+			Punctuation:        -1, // disable punctuation
+		}
+		pass, err := garbler.NewPassword(reqs)
+		if err != nil {
+			return "weakpassword"
+		}
+		// validate that the library actually returned an alphanumeric password
+		re := regexp.MustCompile("^[a-zA-Z1-9]+$")
+		if re.MatchString(pass) {
+			return pass
+		}
+		if attempts == 50 {
+			return "weakpassword"
+		}
+		attempts++
+	}
+}
+
+func IncrementIPv4(ip net.IP) (net.IP, error) {
+
+	if len(ip) != net.IPv4len {
+		return nil, errors.New("IncrementIPv4: only IPv4 addresses supported")
+	}
+
+	if ip.Equal(net.IPv4bcast) {
+		return nil, errors.New("IncrementIPv4: incrementing IPv4 broadcast (255.255.255.255) results in overflow")
+	}
+
+	nextIp := make(net.IP, len(ip))
+	copy(nextIp, ip)
+
+	// increment IP accounting for rollovers at each byte
+	for j := len(nextIp) - 1; j >= 0; j-- {
+		nextIp[j]++
+		if nextIp[j] > 0 {
+			break
+		}
+	}
+
+	return nextIp, nil
+}
+
+func BroadcastIPv4(network net.IPNet) (net.IP, error) {
+	if len(network.IP) != net.IPv4len {
+		return nil, errors.New("BroadcastIPv4: only IPv4 addresses supported")
+	}
+
+	broadcast := net.IP(make([]byte, 4))
+	for i := range network.IP {
+		broadcast[i] = network.IP[i] | ^network.Mask[i]
+	}
+
+	return broadcast, nil
+}
+
+func LoadOrCreatePrivateSSHKey(privateKeyPath string) (*rsa.PrivateKey, error) {
+	blockType := "RSA PRIVATE KEY"
+
+	if _, statErr := os.Stat(privateKeyPath); os.IsNotExist(statErr) {
+		privateKey, generateErr := rsa.GenerateKey(cryptorand.Reader, 1024)
+		if generateErr != nil {
+			return nil, generateErr
+		}
+
+		// generate and write private key as PEM
+		privateKeyFile, createErr := os.Create(privateKeyPath)
+		defer privateKeyFile.Close()
+		if createErr != nil {
+			return nil, createErr
+		}
+
+		privateKeyPEM := &pem.Block{Type: blockType, Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
+		if encodeErr := pem.Encode(privateKeyFile, privateKeyPEM); encodeErr != nil {
+			return nil, encodeErr
+		}
+
+		return privateKey, nil
+	} else {
+		buffer, readErr := ioutil.ReadFile(privateKeyPath)
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		block, rest := pem.Decode(buffer)
+		if len(rest) > 0 {
+			return nil, errors.New("LoadOrCreatePrivateSSHKey: extra data in private key PEM block")
+		}
+
+		if block.Type != blockType {
+			return nil, errors.New(fmt.Sprintf("LoadOrCreatePrivateSSHKey: expecting a block type of %v but got %v", blockType, block.Type))
+		}
+
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	}
+}
+
+func CreatePublicKey(privateKey *rsa.PrivateKey, publicKeyPath string) error {
+	// generate and write public key
+	pub, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(publicKeyPath, ssh.MarshalAuthorizedKey(pub), 0655)
+}

--- a/provision/utils/utils.go
+++ b/provision/utils/utils.go
@@ -40,18 +40,19 @@ func MakeFileAskOnOverwrite(name string) (*os.File, error) {
 
 func AskForConfirmation(prompt string) bool {
 	fmt.Printf("%v  (y/N):", prompt)
-
 	var response string
-	_, err := fmt.Scanln(&response)
-
+	i, err := fmt.Scanln(&response)
 	if err != nil {
-		log.Fatal(err)
+		if i == 0 {
+			response = ""
+		} else {
+			log.Fatal(err)
+		}
 	}
-
 	okayResponseSet := MakeStringSet([]string{"y", "yes"})
+	nokayResponseSet := MakeStringSet([]string{"n", "no"})
 	response = strings.ToLower(response)
-
-	if len(response) == 0 {
+	if len(response) == 0 || StringSetContains(nokayResponseSet, response) {
 		return false
 	} else if StringSetContains(okayResponseSet, response) {
 		return true

--- a/provision/vagrant/cmd.go
+++ b/provision/vagrant/cmd.go
@@ -1,0 +1,192 @@
+package vagrant
+
+import (
+	"fmt"
+
+	"github.com/apprenda/kismatic-provision/provision/utils"
+	"github.com/spf13/cobra"
+)
+
+type VagrantCmdOpts struct {
+	PlanOpts
+	NoPlan                  bool
+	OnlyGenerateVagrantfile bool
+}
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vagrant",
+		Short: "Provision a virtualized infrastructure using Vagrant.",
+		Long:  `Provision a virtualized infrastructure using Vagrant.`,
+	}
+
+	cmd.AddCommand(VagrantCreateCmd())
+	cmd.AddCommand(VagrantCreateMinikubeCmd())
+
+	return cmd
+}
+
+func AddSharedFlags(cmd *cobra.Command, opts *VagrantCmdOpts) {
+	//InfrastructureOps
+	(*cmd).Flags().StringVarP(&opts.NodeCIDR, "nodeCIDR", "c", "192.168.205.0/24", "Network CIDR to use in creating the VM Nodes")
+	(*cmd).Flags().BoolVarP(&opts.Redhat, "useRedHat", "r", true, "If present, will install RedHat 7.3 rather than Ubuntu 16.04")
+	(*cmd).Flags().StringVarP(&opts.PrivateSSHKeyPath, "keypath", "k", "", "Path to private SSH key to use in provisioning VMs.")
+	(*cmd).Flags().StringVarP(&opts.Vagrantfile, "vagrantfile", "f", "Vagrantfile", "Path to Vagrantfile to generate")
+
+	//PlanOpts
+	(*cmd).Flags().BoolVar(&opts.AllowPackageInstallation, "allowPackageInstallation", true, "If true, allows os packages to be installed automatically")
+	(*cmd).Flags().BoolVar(&opts.AutoConfiguredDockerRegistry, "autoConfiguredDockerRegistry", true, "If true, installs a auto-configured Docker registry")
+	(*cmd).Flags().StringVar(&opts.DockerRegistryHost, "dockerRegistryIP", "", "IP or hostname for your Docker registry. An internal registry will NOT be setup when this field is provided. Must be accessible from all the nodes in the cluster.")
+	(*cmd).Flags().Uint16Var(&opts.DockerRegistryPort, "dockerRegistryPort", 443, "Port for your Docker registry")
+	(*cmd).Flags().StringVar(&opts.DockerRegistryCAPath, "dockerRegistryCAPath", "", "Absolute path to the CA that was used when starting your Docker registry. The docker daemons on all nodes in the cluster will be configured with this CA.")
+	(*cmd).Flags().StringVar(&opts.AdminPassword, "adminPassword", utils.GenerateAlphaNumericPassword(), "This password is used to login to the Kubernetes Dashboard and can also be used for administration without a security certificate")
+	(*cmd).Flags().StringVar(&opts.PodCIDR, "podCIDR", "172.168.16.0/16", "Kubernetes will assign pods IPs in this range. Do not use a range that is already in use on your local network!")
+	(*cmd).Flags().StringVar(&opts.ServiceCIDR, "serviceCIDR", "172.168.17.0/16", "Kubernetes will assign services IPs in this range. Do not use a range that is already in use by your local network or pod network!")
+
+	// VagrantCmdOpts
+	(*cmd).Flags().BoolVar(&opts.OnlyGenerateVagrantfile, "onlyGenerateVagrantFile", false, "If present, forgoes performing `vagrant up` on the generated Vagrantfile")
+	(*cmd).Flags().BoolVar(&opts.NoPlan, "noplan", false, "If present, foregoes generating a plan file in this directory referencing the newly created nodes")
+}
+
+func VagrantCreateCmd() *cobra.Command {
+	var etcdCount, masterCount, workerCount, ingressCount uint16
+
+	opts := VagrantCmdOpts{
+		PlanOpts: PlanOpts{
+			InfrastructureOpts: InfrastructureOpts{
+				Count: map[NodeType]uint16{},
+			},
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Creates infrastructure for a new cluster.",
+		Long: `Creates infrastructure for a new cluster.
+
+Smallish instances will be created with public IP addresses. Unless option onlyGenerateVagrantfile is true, the command will not return 
+until the instances are all online and accessible via SSH.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Count[Etcd] = etcdCount
+			opts.Count[Master] = masterCount
+			opts.Count[Worker] = workerCount
+			opts.Count[Ingress] = ingressCount
+			return makeInfrastructure(&opts)
+		},
+	}
+
+	cmd.Flags().Uint16VarP(&etcdCount, "etcdNodeCount", "e", 1, "Count of etcd nodes to produce.")
+	cmd.Flags().Uint16VarP(&masterCount, "masterdNodeCount", "m", 1, "Count of master nodes to produce.")
+	cmd.Flags().Uint16VarP(&workerCount, "workerNodeCount", "w", 1, "Count of worker nodes to produce.")
+	cmd.Flags().Uint16VarP(&ingressCount, "ingressNodeCount", "i", 1, "Count of ingress nodes to produce")
+	cmd.Flags().BoolVar(&opts.OverlapRoles, "overlapRoles", false, "Overlap roles to create as few nodes as possible")
+
+	AddSharedFlags(cmd, &opts)
+
+	return cmd
+}
+
+func VagrantCreateMinikubeCmd() *cobra.Command {
+	opts := VagrantCmdOpts{
+		PlanOpts: PlanOpts{
+			InfrastructureOpts: InfrastructureOpts{
+				Count: map[NodeType]uint16{
+					Etcd:    1,
+					Master:  1,
+					Worker:  1,
+					Ingress: 1,
+				},
+				OverlapRoles: true,
+			},
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create-mini",
+		Short: "Creates infrastructure for a single-node instance.",
+		Long: `Creates infrastructure for a single-node instance. 
+
+A smallish instance will be created with public IP addresses. The command will not return until the instance is online and accessible via SSH.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return makeInfrastructure(&opts)
+		},
+	}
+
+	AddSharedFlags(cmd, &opts)
+
+	return cmd
+}
+
+func makeInfrastructure(opts *VagrantCmdOpts) error {
+	infrastructure, infraErr := NewInfrastructure(&opts.InfrastructureOpts)
+	if infraErr != nil {
+		return infraErr
+	}
+
+	_, vagrantErr := createVagrantfile(opts, infrastructure)
+	if vagrantErr != nil {
+		return vagrantErr
+	}
+
+	if opts.OnlyGenerateVagrantfile {
+		fmt.Println("To create your local VMs, run:")
+		fmt.Println("vagrant up")
+	} else {
+		if vagrantUpErr := vagrantUp(); vagrantUpErr != nil {
+			return vagrantUpErr
+		}
+	}
+
+	if !opts.NoPlan {
+		planFile, planErr := createPlan(opts, infrastructure)
+		if planErr != nil {
+			return planErr
+		}
+
+		fmt.Println("To install your cluster, run:")
+		fmt.Println("./kismatic install apply -f " + planFile)
+	}
+
+	return nil
+}
+
+func createVagrantfile(opts *VagrantCmdOpts, infrastructure *Infrastructure) (string, error) {
+	vagrantfile, err := utils.MakeFileAskOnOverwrite("Vagrantfile")
+	if err != nil {
+		return "", err
+	}
+
+	defer vagrantfile.Close()
+
+	vagrant := &Vagrant{
+		Opts:           &opts.InfrastructureOpts,
+		Infrastructure: infrastructure,
+	}
+
+	err = vagrant.Write(vagrantfile)
+	if err != nil {
+		return "", err
+	}
+
+	return vagrantfile.Name(), nil
+}
+
+func createPlan(opts *VagrantCmdOpts, infrastructure *Infrastructure) (string, error) {
+	planFile, err := utils.MakeUniqueFile("kismatic-cluster", ".yaml", 0)
+	if err != nil {
+		return "", err
+	}
+
+	defer planFile.Close()
+
+	plan := &Plan{
+		Opts:           &opts.PlanOpts,
+		Infrastructure: infrastructure,
+	}
+
+	err = plan.Write(planFile)
+	if err != nil {
+		return "", err
+	}
+
+	return planFile.Name(), nil
+}

--- a/provision/vagrant/cmd.go
+++ b/provision/vagrant/cmd.go
@@ -28,23 +28,29 @@ func Cmd() *cobra.Command {
 
 func AddSharedFlags(cmd *cobra.Command, opts *VagrantCmdOpts) {
 	//InfrastructureOps
-	(*cmd).Flags().StringVarP(&opts.NodeCIDR, "nodeCIDR", "c", "192.168.205.0/24", "Network CIDR to use in creating the VM Nodes")
-	(*cmd).Flags().BoolVarP(&opts.Redhat, "useRedHat", "r", true, "If present, will install RedHat 7.3 rather than Ubuntu 16.04")
-	(*cmd).Flags().StringVarP(&opts.PrivateSSHKeyPath, "keypath", "k", "", "Path to private SSH key to use in provisioning VMs.")
-	(*cmd).Flags().StringVarP(&opts.Vagrantfile, "vagrantfile", "f", "Vagrantfile", "Path to Vagrantfile to generate")
+	//(*cmd).Flags().StringVarP(&opts.NodeCIDR, "nodeCIDR", "c", "192.168.205.0/24", "Network CIDR to use in creating the VM Nodes")
+	opts.NodeCIDR = "192.168.42.2/24"
+	(*cmd).Flags().BoolVarP(&opts.Redhat, "useCentOS", "r", false, "If present, will install CentOS 7.3 rather than Ubuntu 16.04")
+	// (*cmd).Flags().StringVarP(&opts.PrivateSSHKeyPath, "keypath", "k", "", "Path to private SSH key to use in provisioning VMs.")
+	//(*cmd).Flags().StringVarP(&opts.Vagrantfile, "vagrantfile", "f", "Vagrantfile", "Path to Vagrantfile to generate")
+	opts.Vagrantfile = "Vagrantfile"
 
 	//PlanOpts
-	(*cmd).Flags().BoolVar(&opts.AllowPackageInstallation, "allowPackageInstallation", true, "If true, allows os packages to be installed automatically")
-	(*cmd).Flags().BoolVar(&opts.AutoConfiguredDockerRegistry, "autoConfiguredDockerRegistry", true, "If true, installs a auto-configured Docker registry")
-	(*cmd).Flags().StringVar(&opts.DockerRegistryHost, "dockerRegistryIP", "", "IP or hostname for your Docker registry. An internal registry will NOT be setup when this field is provided. Must be accessible from all the nodes in the cluster.")
-	(*cmd).Flags().Uint16Var(&opts.DockerRegistryPort, "dockerRegistryPort", 443, "Port for your Docker registry")
-	(*cmd).Flags().StringVar(&opts.DockerRegistryCAPath, "dockerRegistryCAPath", "", "Absolute path to the CA that was used when starting your Docker registry. The docker daemons on all nodes in the cluster will be configured with this CA.")
+	// (*cmd).Flags().BoolVar(&opts.AllowPackageInstallation, "allowPackageInstallation", true, "If true, allows os packages to be installed automatically")
+	opts.AllowPackageInstallation = true
+	//(*cmd).Flags().BoolVar(&opts.AutoConfiguredDockerRegistry, "autoConfiguredDockerRegistry", true, "If true, installs a auto-configured Docker registry")
+	opts.AutoConfiguredDockerRegistry = true
+	// (*cmd).Flags().StringVar(&opts.DockerRegistryHost, "dockerRegistryIP", "", "IP or hostname for your Docker registry. An internal registry will NOT be setup when this field is provided. Must be accessible from all the nodes in the cluster.")
+	// (*cmd).Flags().Uint16Var(&opts.DockerRegistryPort, "dockerRegistryPort", 443, "Port for your Docker registry")
+	// (*cmd).Flags().StringVar(&opts.DockerRegistryCAPath, "dockerRegistryCAPath", "", "Absolute path to the CA that was used when starting your Docker registry. The docker daemons on all nodes in the cluster will be configured with this CA.")
 	(*cmd).Flags().StringVar(&opts.AdminPassword, "adminPassword", utils.GenerateAlphaNumericPassword(), "This password is used to login to the Kubernetes Dashboard and can also be used for administration without a security certificate")
-	(*cmd).Flags().StringVar(&opts.PodCIDR, "podCIDR", "172.168.16.0/16", "Kubernetes will assign pods IPs in this range. Do not use a range that is already in use on your local network!")
-	(*cmd).Flags().StringVar(&opts.ServiceCIDR, "serviceCIDR", "172.168.17.0/16", "Kubernetes will assign services IPs in this range. Do not use a range that is already in use by your local network or pod network!")
-
+	opts.AdminPassword = utils.GenerateAlphaNumericPassword()
+	// (*cmd).Flags().StringVar(&opts.PodCIDR, "podCIDR", "172.168.16.0/16", "Kubernetes will assign pods IPs in this range. Do not use a range that is already in use on your local network!")
+	opts.PodCIDR = "172.168.16.0/16"
+	// (*cmd).Flags().StringVar(&opts.ServiceCIDR, "serviceCIDR", "172.168.17.0/16", "Kubernetes will assign services IPs in this range. Do not use a range that is already in use by your local network or pod network!")
+	opts.ServiceCIDR = "172.168.17.0/16"
 	// VagrantCmdOpts
-	(*cmd).Flags().BoolVar(&opts.OnlyGenerateVagrantfile, "onlyGenerateVagrantFile", false, "If present, forgoes performing `vagrant up` on the generated Vagrantfile")
+	// (*cmd).Flags().BoolVar(&opts.OnlyGenerateVagrantfile, "onlyGenerateVagrantFile", false, "If present, forgoes performing `vagrant up` on the generated Vagrantfile")
 	(*cmd).Flags().BoolVar(&opts.NoPlan, "noplan", false, "If present, foregoes generating a plan file in this directory referencing the newly created nodes")
 }
 
@@ -77,8 +83,8 @@ until the instances are all online and accessible via SSH.`,
 	cmd.Flags().Uint16VarP(&etcdCount, "etcdNodeCount", "e", 1, "Count of etcd nodes to produce.")
 	cmd.Flags().Uint16VarP(&masterCount, "masterdNodeCount", "m", 1, "Count of master nodes to produce.")
 	cmd.Flags().Uint16VarP(&workerCount, "workerNodeCount", "w", 1, "Count of worker nodes to produce.")
-	cmd.Flags().Uint16VarP(&ingressCount, "ingressNodeCount", "i", 1, "Count of ingress nodes to produce")
-	cmd.Flags().BoolVar(&opts.OverlapRoles, "overlapRoles", false, "Overlap roles to create as few nodes as possible")
+	// cmd.Flags().Uint16VarP(&ingressCount, "ingressNodeCount", "i", 1, "Count of ingress nodes to produce")
+	// cmd.Flags().BoolVar(&opts.OverlapRoles, "overlapRoles", false, "Overlap roles to create as few nodes as possible")
 
 	AddSharedFlags(cmd, &opts)
 
@@ -135,6 +141,8 @@ func makeInfrastructure(opts *VagrantCmdOpts) error {
 			return vagrantUpErr
 		}
 	}
+
+	infrastructure.PrivateSSHKeyPath = grabSSHConfig()
 
 	if !opts.NoPlan {
 		planFile, planErr := createPlan(opts, infrastructure)

--- a/provision/vagrant/cmd.go
+++ b/provision/vagrant/cmd.go
@@ -45,10 +45,10 @@ func AddSharedFlags(cmd *cobra.Command, opts *VagrantCmdOpts) {
 	// (*cmd).Flags().StringVar(&opts.DockerRegistryCAPath, "dockerRegistryCAPath", "", "Absolute path to the CA that was used when starting your Docker registry. The docker daemons on all nodes in the cluster will be configured with this CA.")
 	(*cmd).Flags().StringVar(&opts.AdminPassword, "adminPassword", utils.GenerateAlphaNumericPassword(), "This password is used to login to the Kubernetes Dashboard and can also be used for administration without a security certificate")
 	opts.AdminPassword = utils.GenerateAlphaNumericPassword()
-	// (*cmd).Flags().StringVar(&opts.PodCIDR, "podCIDR", "172.168.16.0/16", "Kubernetes will assign pods IPs in this range. Do not use a range that is already in use on your local network!")
-	opts.PodCIDR = "172.168.16.0/16"
-	// (*cmd).Flags().StringVar(&opts.ServiceCIDR, "serviceCIDR", "172.168.17.0/16", "Kubernetes will assign services IPs in this range. Do not use a range that is already in use by your local network or pod network!")
-	opts.ServiceCIDR = "172.168.17.0/16"
+	// (*cmd).Flags().StringVar(&opts.PodCIDR, "podCIDR", "172.16.0.0/16", "Kubernetes will assign pods IPs in this range. Do not use a range that is already in use on your local network!")
+	opts.PodCIDR = "172.16.0.0/16"
+	// (*cmd).Flags().StringVar(&opts.ServiceCIDR, "serviceCIDR", "172.17.0.0/16", "Kubernetes will assign services IPs in this range. Do not use a range that is already in use by your local network or pod network!")
+	opts.ServiceCIDR = "172.17.0.0/16"
 	// VagrantCmdOpts
 	// (*cmd).Flags().BoolVar(&opts.OnlyGenerateVagrantfile, "onlyGenerateVagrantFile", false, "If present, forgoes performing `vagrant up` on the generated Vagrantfile")
 	(*cmd).Flags().BoolVar(&opts.NoPlan, "noplan", false, "If present, foregoes generating a plan file in this directory referencing the newly created nodes")

--- a/provision/vagrant/infrastructure.go
+++ b/provision/vagrant/infrastructure.go
@@ -70,10 +70,10 @@ func NewInfrastructure(opts *InfrastructureOpts) (*Infrastructure, error) {
 		Nodes:     []NodeDetails{},
 	}
 
-	sshError := i.ensureSSHKeys(opts.PrivateSSHKeyPath)
-	if sshError != nil {
-		return nil, sshError
-	}
+	// sshError := i.ensureSSHKeys(opts.PrivateSSHKeyPath)
+	// if sshError != nil {
+	// 	return nil, sshError
+	// }
 
 	var overlapTypes NodeType
 

--- a/provision/vagrant/infrastructure.go
+++ b/provision/vagrant/infrastructure.go
@@ -1,0 +1,206 @@
+package vagrant
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/apprenda/kismatic-provision/provision/utils"
+)
+
+type NodeType uint32
+
+const (
+	Etcd NodeType = 1 << iota
+	Master
+	Worker
+	Ingress
+)
+
+var NodeTypes = []NodeType{Etcd, Master, Worker, Ingress}
+
+var NodeTypeStrings = map[NodeType]string{
+	Etcd:    "etcd",
+	Master:  "master",
+	Worker:  "worker",
+	Ingress: "ingress",
+}
+
+type InfrastructureOpts struct {
+	Count             map[NodeType]uint16
+	OverlapRoles      bool
+	NodeCIDR          string
+	Redhat            bool
+	PrivateSSHKeyPath string
+	Vagrantfile       string
+}
+
+type NodeDetails struct {
+	Name  string
+	IP    net.IP
+	Types NodeType
+}
+
+type Infrastructure struct {
+	Network           net.IPNet
+	Broadcast         net.IP
+	Nodes             []NodeDetails
+	DNSReflector      string
+	PrivateSSHKeyPath string
+	PublicSSHKeyPath  string
+}
+
+func NewInfrastructure(opts *InfrastructureOpts) (*Infrastructure, error) {
+	_, network, err := net.ParseCIDR(opts.NodeCIDR)
+
+	if err != nil {
+		return nil, err
+	}
+
+	broadcast, err := utils.BroadcastIPv4(*network)
+	if err != nil {
+		return nil, err
+	}
+
+	i := &Infrastructure{
+		Network:   *network,
+		Broadcast: broadcast,
+		Nodes:     []NodeDetails{},
+	}
+
+	sshError := i.ensureSSHKeys(opts.PrivateSSHKeyPath)
+	if sshError != nil {
+		return nil, sshError
+	}
+
+	var overlapTypes NodeType
+
+	// keep creating nodes until counts are exhausted
+	for j := uint16(1); ; j++ {
+		overlapTypes = NodeType(0)
+		finished := true
+
+		for _, nodeType := range NodeTypes {
+			if j <= opts.Count[nodeType] {
+				if opts.OverlapRoles {
+					overlapTypes |= nodeType
+				} else {
+					_, err := i.appendNode(j, NodeTypeStrings[nodeType], nodeType)
+					if err != nil {
+						return i, err
+					}
+				}
+				finished = false
+			}
+		}
+
+		if overlapTypes > 0 {
+			_, err := i.appendNode(j, "node", overlapTypes)
+			if err != nil {
+				return i, err
+			}
+		}
+
+		if finished {
+			break
+		}
+	}
+
+	return i, nil
+}
+
+func (i *Infrastructure) ensureSSHKeys(privateSSHKeyPath string) error {
+
+	if privateSSHKeyPath == "" {
+		i.PrivateSSHKeyPath = "kismatic-cluster.pem"
+	} else {
+		i.PrivateSSHKeyPath = privateSSHKeyPath
+	}
+
+	// ensure absolute path
+	var absErr error
+	i.PrivateSSHKeyPath, absErr = filepath.Abs(i.PrivateSSHKeyPath)
+	if absErr != nil {
+		return absErr
+	}
+
+	i.PublicSSHKeyPath = i.PrivateSSHKeyPath + ".pub"
+
+	privateKey, privateKeyErr := utils.LoadOrCreatePrivateSSHKey(i.PrivateSSHKeyPath)
+	if privateKeyErr != nil {
+		return privateKeyErr
+	}
+
+	publicKeyErr := utils.CreatePublicKey(privateKey, i.PublicSSHKeyPath)
+	if publicKeyErr != nil {
+		return publicKeyErr
+	}
+
+	// ensure correct permissions
+	os.Chmod(i.PrivateSSHKeyPath, 0600)
+	os.Chmod(i.PublicSSHKeyPath, 0600)
+
+	return nil
+}
+
+func (i *Infrastructure) appendNode(nodeIndex uint16, name string, types NodeType) (*NodeDetails, error) {
+	ip, err := i.nextNodeIP()
+
+	if err != nil {
+		return nil, err
+	}
+
+	hostname := fmt.Sprintf("%v%03d", name, nodeIndex)
+
+	node := NodeDetails{
+		Name:  hostname,
+		IP:    ip,
+		Types: types,
+	}
+
+	i.Nodes = append(i.Nodes, node)
+
+	return &node, nil
+}
+
+func (i *Infrastructure) nextNodeIP() (net.IP, error) {
+	var ip net.IP
+	var err error
+
+	if len(i.Nodes) < 1 {
+		ip = i.Network.IP
+
+		// increment by 1 to account for gateway
+		ip, err = utils.IncrementIPv4(ip)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		lastNode := i.Nodes[len(i.Nodes)-1:][0]
+		ip = lastNode.IP
+	}
+
+	ip, err = utils.IncrementIPv4(ip)
+	if err != nil {
+		return nil, err
+	}
+
+	// assumes broadcast address is last host in CIDR range
+	if !i.Network.Contains(ip) || i.Broadcast.Equal(ip) {
+		return ip, errors.New("infrastructure: ip address overflowed available cidr range")
+	}
+
+	return ip, nil
+}
+
+func (i *Infrastructure) nodesByType(nodeType NodeType) []NodeDetails {
+	filtered := []NodeDetails{}
+	for _, node := range i.Nodes {
+		if (node.Types & nodeType) > NodeType(0) {
+			filtered = append(filtered, node)
+		}
+	}
+	return filtered
+}

--- a/provision/vagrant/planfile.go
+++ b/provision/vagrant/planfile.go
@@ -1,0 +1,102 @@
+package vagrant
+
+import (
+	"bufio"
+	"html/template"
+	"os"
+)
+
+type PlanOpts struct {
+	InfrastructureOpts
+	AllowPackageInstallation     bool
+	AutoConfiguredDockerRegistry bool
+	DockerRegistryHost           string
+	DockerRegistryPort           uint16
+	DockerRegistryCAPath         string
+	AdminPassword                string
+	PodCIDR                      string
+	ServiceCIDR                  string
+}
+
+type Plan struct {
+	Opts           *PlanOpts
+	Infrastructure *Infrastructure
+}
+
+func (p *Plan) Write(file *os.File) error {
+	template, err := template.New("planVagrantOverlay").Parse(planVagrantOverlay)
+	if err != nil {
+		return err
+	}
+
+	w := bufio.NewWriter(file)
+
+	if err = template.Execute(w, &p); err != nil {
+		return err
+	}
+
+	w.Flush()
+
+	return nil
+}
+
+func (p *Plan) Etcd() []NodeDetails {
+	return p.Infrastructure.nodesByType(Etcd)
+}
+
+func (p *Plan) Master() []NodeDetails {
+	return p.Infrastructure.nodesByType(Master)
+}
+
+func (p *Plan) Worker() []NodeDetails {
+	return p.Infrastructure.nodesByType(Worker)
+}
+
+func (p *Plan) Ingress() []NodeDetails {
+	return p.Infrastructure.nodesByType(Ingress)
+}
+
+const planVagrantOverlay = `cluster:
+  name: kubernetes
+  admin_password: {{.Opts.AdminPassword}}      # This password is used to login to the Kubernetes Dashboard and can also be used for administration without a security certificate
+  allow_package_installation: {{.Opts.AllowPackageInstallation}}      # When false, installation will not occur if any node is missing the correct deb/rpm packages. When true, the installer will attempt to install missing packages for you.
+  networking:
+    type: overlay                        # overlay or routed. Routed pods can be addressed from outside the Kubernetes cluster; Overlay pods can only address each other.
+    pod_cidr_block: {{.Opts.PodCIDR}}        # Kubernetes will assign pods IPs in this range. Do not use a range that is already in use on your local network!
+    service_cidr_block: {{.Opts.ServiceCIDR}}   # Kubernetes will assign services IPs in this range. Do not use a range that is already in use by your local network or pod network!
+    policy_enabled: false                # When true, enables network policy enforcement on the Kubernetes Pod network. This is an advanced feature.
+    update_hosts_files: true            # When true, the installer will add entries for all nodes to other nodes' hosts files. Use when you don't have access to DNS.
+  certificates:
+    expiry: 17520h                       # Self-signed certificate expiration period in hours; default is 2 years.
+  ssh:
+    user: vagrant
+    ssh_key: {{.Infrastructure.PrivateSSHKeyPath}}             # Absolute path to the ssh public key we should use to manage nodes.
+    ssh_port: 22
+docker_registry:                         # Here you will provide the details of your Docker registry or setup an internal one to run in the cluster. This is optional and the cluster will always have access to the Docker Hub.
+  setup_internal: {{.Opts.AutoConfiguredDockerRegistry}}                  # When true, a Docker Registry will be installed on top of your cluster and used to host Docker images needed for its installation.
+  address: {{.Opts.DockerRegistryHost}}                            # IP or hostname for your Docker registry. An internal registry will NOT be setup when this field is provided. Must be accessible from all the nodes in the cluster.
+  port: {{.Opts.DockerRegistryPort}}                              # Port for your Docker registry.
+  CA: {{.Opts.DockerRegistryCAPath}}                                 # Absolute path to the CA that was used when starting your Docker registry. The docker daemons on all nodes in the cluster will be configured with this CA.
+etcd:
+  expected_count: {{len .Etcd}}
+  nodes:{{range .Etcd}}
+  - host: {{.Name}}
+    ip: {{.IP.String}}{{end}}
+master:
+  expected_count: {{len .Master}}
+  nodes:{{range .Master}}
+  - host: {{.Name}}
+    ip: {{.IP.String}}{{end}}
+  load_balanced_fqdn: {{with index .Master 0 }}{{.IP.String}}{{end}}
+  load_balanced_short_name: {{with index .Master 0}}{{.IP.String}}{{end}}
+worker:
+  expected_count: {{len .Worker}}
+  nodes:{{range .Worker}}
+  - host: {{.Name}}
+    ip: {{.IP.String}}{{end}}
+ingress:
+  expected_count: {{len .Ingress}}
+  nodes:{{range .Ingress}}
+  - host: {{.Name}}
+    ip: {{.IP.String}}{{end}}
+`

--- a/provision/vagrant/planfile.go
+++ b/provision/vagrant/planfile.go
@@ -53,7 +53,7 @@ func (p *Plan) Worker() []NodeDetails {
 }
 
 func (p *Plan) Ingress() []NodeDetails {
-	return p.Infrastructure.nodesByType(Ingress)
+	return p.Infrastructure.nodesByType(Worker)[0:1]
 }
 
 const planVagrantOverlay = `cluster:

--- a/provision/vagrant/vagrantclient.go
+++ b/provision/vagrant/vagrantclient.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 )
 
 const vagrantCmd string = "vagrant"
@@ -16,6 +17,26 @@ func ensureVagrantOnPath() string {
 		log.Fatal("Unable to locate vagrant on path.  It can be downloaded from http://www.vagrantup.com")
 	}
 	return path
+}
+
+func grabSSHConfig() string {
+	cmd := exec.Command("vagrant", "ssh-config")
+	bytes, err := cmd.CombinedOutput()
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error getting ssh config for newly created vagrant image", err)
+		os.Exit(1)
+	}
+
+	r, err := regexp.Compile(`.*IdentityFile\ (.*)`)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error compiling regex", err)
+		os.Exit(1)
+	}
+
+	a := r.FindSubmatch(bytes)
+
+	return string(a[1])
 }
 
 func vagrantUp() error {

--- a/provision/vagrant/vagrantclient.go
+++ b/provision/vagrant/vagrantclient.go
@@ -1,0 +1,53 @@
+package vagrant
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+)
+
+const vagrantCmd string = "vagrant"
+
+func ensureVagrantOnPath() string {
+	path, err := exec.LookPath(vagrantCmd)
+	if err != nil {
+		log.Fatal("Unable to locate vagrant on path.  It can be downloaded from http://www.vagrantup.com")
+	}
+	return path
+}
+
+func vagrantUp() error {
+	cmdPath := ensureVagrantOnPath()
+
+	cmdArgs := []string{"up"}
+	cmd := exec.Command(cmdPath, cmdArgs...)
+
+	cmdReader, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating StdoutPipe for Cmd", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(cmdReader)
+	go func() {
+		for scanner.Scan() {
+			fmt.Printf("%s\n", scanner.Text())
+		}
+	}()
+
+	fmt.Printf("executing '%v up'\n", vagrantCmd)
+	err = cmd.Start()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error starting Cmd", err)
+		os.Exit(1)
+	}
+
+	cmdErr := cmd.Wait()
+	if cmdErr != nil {
+		return cmdErr
+	}
+
+	return nil
+}

--- a/provision/vagrant/vagrantfile.go
+++ b/provision/vagrant/vagrantfile.go
@@ -1,0 +1,81 @@
+package vagrant
+
+import (
+	"bufio"
+	"html/template"
+	"os"
+)
+
+type Vagrant struct {
+	Opts           *InfrastructureOpts
+	Infrastructure *Infrastructure
+	UnescapedLTLT  template.HTML
+	UnescapedGTGT  template.HTML
+}
+
+func (v *Vagrant) Write(file *os.File) error {
+
+	v.UnescapedGTGT = template.HTML(">>")
+	v.UnescapedLTLT = template.HTML("<<")
+
+	template, err := template.New("vagrantfileOverlay").Parse(vagrantfileOverlay)
+	if err != nil {
+		return err
+	}
+
+	w := bufio.NewWriter(file)
+
+	if err = template.Execute(w, &v); err != nil {
+		return err
+	}
+
+	w.Flush()
+
+	return nil
+}
+
+const vagrantfileOverlay = `boxes = [
+    {{range $index,$element := .Infrastructure.Nodes}}{{if $index}},{{end}}{
+        :name => "{{.Name}}",
+        :eth1 => "{{.IP.String}}",
+        :mem => "1024",
+        :cpu => "1"
+    }{{end}}
+]
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "{{if .Opts.Redhat}}centos/7{{else}}ubuntu/xenial64{{end}}"
+  config.ssh.insert_key = false
+
+  # Add the ssh public key to the node
+  config.vm.provision "shell" do |s|
+    ssh_pub_key = File.readlines("{{.Infrastructure.PublicSSHKeyPath}}").first.strip
+    s.inline = {{.UnescapedLTLT}}-SHELL
+      mkdir -p /root/.ssh
+      echo #{ssh_pub_key} {{.UnescapedGTGT}} /home/vagrant/.ssh/authorized_keys
+      echo #{ssh_pub_key} {{.UnescapedGTGT}} /root/.ssh/authorized_keys
+    SHELL
+  end
+
+  # Turn off shared folders
+  config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+
+  boxes.each do |opts|
+    config.vm.define opts[:name] do |config|
+      config.vm.hostname = opts[:name]
+
+      config.vm.provider "vmware_fusion" do |v|
+        v.vmx["memsize"] = opts[:mem]
+        v.vmx["numvcpus"] = opts[:cpu]
+      end
+
+      config.vm.provider "virtualbox" do |v|
+        v.customize ["modifyvm", :id, "--memory", opts[:mem]]
+        v.customize ["modifyvm", :id, "--cpus", opts[:cpu]]
+      end
+
+      config.vm.network :private_network, ip: opts[:eth1]
+    end
+  end
+end`


### PR DESCRIPTION
Cody McCain made a great step forward for vagrant provisioning with his PR. However, he also added a few novel new ideas to provisioning, such as controllable IP spaces and automatic packing of roles across nodes.

All this complexity provides potential capabilities to end users, at the cost of rather long command line calls. Being that simplicity and predictability are two goals of the provision tool, I have created this alternate PR.

This PR disables many of the more advanced switches in Cody's PR, reducing the argument count to about 4. It includes a simplification of public & private key management that relies on the unsafe common public keys already in use in bento boxes (which have also been adopted).

All the functionality remains and we can choose to roll it out if it is requested. When doing so, we would prefer to offer similar functionality in the other target infrastructure providers.