### PR TITLE
Storage provision option for AWS, Packet

### DIFF
--- a/provision/packet/create.go
+++ b/provision/packet/create.go
@@ -35,6 +35,8 @@ provision packet create --useCentos`,
 	cmd.Flags().BoolVar(&opts.CentOS, "useCentos", false, "If present, will install CentOS 7 rather than Ubuntu 16.04")
 	cmd.Flags().BoolVarP(&opts.NoPlan, "noplan", "n", false, "If present, foregoes generating a plan file in this directory referencing the newly created nodes")
 	cmd.Flags().StringVar(&opts.Region, "region", "us-east", "The region to be used for provisioning machines. One of us-east|us-west|eu-west")
+	cmd.Flags().BoolVarP(&opts.Storage, "storage-cluster", "s", false, "Create a storage cluster from all Worker nodes.")
+
 	return cmd
 }
 
@@ -147,12 +149,18 @@ func runCreate(opts *packetOpts) error {
 		return nil
 	}
 
+	storageNodes := []plan.Node{}
+	if opts.Storage {
+		storageNodes = nodes.worker
+	}
+
 	// Write the plan file out
 	planit := plan.Plan{
 		Etcd:                nodes.etcd,
 		Master:              nodes.master,
 		Worker:              nodes.worker,
 		Ingress:             nodes.worker[0:1],
+		Storage:             storageNodes,
 		MasterNodeFQDN:      nodes.master[0].PublicIPv4,
 		MasterNodeShortName: nodes.master[0].PublicIPv4,
 		SSHUser:             nodes.master[0].SSHUser,

--- a/provision/packet/create_minikube.go
+++ b/provision/packet/create_minikube.go
@@ -13,7 +13,7 @@ import (
 func createMinikubeCmd() *cobra.Command {
 	opts := &packetOpts{}
 	cmd := &cobra.Command{
-		Use:   "create-minikube",
+		Use:   "create-mini",
 		Short: "Creates infrastructure for a single node cluster.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreateMinikube(opts)

--- a/provision/packet/create_minikube.go
+++ b/provision/packet/create_minikube.go
@@ -22,6 +22,8 @@ func createMinikubeCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.CentOS, "useCentos", false, "If present, will install CentOS 7 rather than Ubuntu 16.04")
 	cmd.Flags().BoolVarP(&opts.NoPlan, "noplan", "n", false, "If present, foregoes generating a plan file in this directory referencing the newly created nodes")
 	cmd.Flags().StringVar(&opts.Region, "region", "us-east", "The region to be used for provisioning machines. One of us-east|us-west|eu-west")
+	cmd.Flags().BoolVarP(&opts.Storage, "storage-cluster", "s", false, "Create a storage cluster from all Worker nodes.")
+
 	return cmd
 }
 
@@ -69,11 +71,17 @@ func runCreateMinikube(opts *packetOpts) error {
 		return err
 	}
 
+	storageNodes := []plan.Node{}
+	if opts.Storage {
+		storageNodes = []plan.Node{*node}
+	}
+
 	plan := plan.Plan{
 		Etcd:                []plan.Node{*node},
 		Master:              []plan.Node{*node},
 		Worker:              []plan.Node{*node},
 		Ingress:             []plan.Node{*node},
+		Storage:             storageNodes,
 		MasterNodeFQDN:      node.PublicIPv4,
 		MasterNodeShortName: node.PublicIPv4,
 		SSHUser:             node.SSHUser,

--- a/provision/packet/packet.go
+++ b/provision/packet/packet.go
@@ -9,6 +9,7 @@ type packetOpts struct {
 	CentOS          bool
 	NoPlan          bool
 	Region          string
+	Storage         bool
 }
 
 // Cmd returns the command for managing Packet infrastructure
@@ -27,7 +28,6 @@ Optional:
   PACKET_SSH_KEY_PATH: The path to the SSH key to be used for accessing the machines.
     If empty, a file called "kismatic-packet.pem" in the current working directory is
     used as the SSH key.
-
 `,
 	}
 	cmd.AddCommand(createCmd())

--- a/provision/plan/patterns.go
+++ b/provision/plan/patterns.go
@@ -5,6 +5,7 @@ type Plan struct {
 	Master              []Node
 	Worker              []Node
 	Ingress             []Node
+	Storage             []Node
 	MasterNodeFQDN      string
 	MasterNodeShortName string
 	SSHUser             string
@@ -56,6 +57,12 @@ worker:
 ingress:
   expected_count: {{len .Ingress}}
   nodes:{{range .Ingress}}
+  - host: {{.Host}}
+    ip: {{.PublicIPv4}}
+    internalip: {{.PrivateIPv4}}{{end}}
+storage:
+  expected_count: {{len .Storage}}
+  nodes:{{range .Storage}}
   - host: {{.Host}}
     ip: {{.PublicIPv4}}
     internalip: {{.PrivateIPv4}}{{end}}


### PR DESCRIPTION
To go along with KET 1.2's storage cluster option, I've added a `-s` flag to AWS and Packet `create` and `create-mini` commands. If present, this will add the storage role to each worker on the cluster.

Default behavior remains the creation of clusters without storage.