### PR TITLE
Use correct hostnames in rhel provision

### DIFF
--- a/provision/aws/client.go
+++ b/provision/aws/client.go
@@ -27,6 +27,7 @@ type Node struct {
 	PrivateIP      string
 	PublicIP       string
 	SSHUser        string
+	ImageID        string
 }
 
 // AMI is the Amazon Machine Image
@@ -208,6 +209,7 @@ func (c Client) GetNode(id string) (*Node, error) {
 		PrivateIP:      *instance.PrivateIpAddress,
 		PublicIP:       publicIP,
 		SSHUser:        defaultSSHUserForAMI(AMI(*instance.ImageId)),
+		ImageID:        *instance.ImageId,
 	}, nil
 }
 

--- a/provision/aws/provision.go
+++ b/provision/aws/provision.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/apprenda/kismatic-provision/provision/plan"
+	"github.com/apprenda/kismatic/integration/aws"
 )
 
 const (
@@ -239,6 +240,10 @@ func (p awsProvisioner) updateNodeWithDeets(nodeID string, node *plan.Node) erro
 		// Get the hostname from the DNS name
 		re := regexp.MustCompile("[^.]*")
 		hostname := re.FindString(awsNode.PrivateDNSName)
+		// RedHat uses FQDN as the hostname
+		if awsNode.ImageID == string(aws.RedHat7East) {
+			hostname = awsNode.PrivateDNSName
+		}
 		node.Host = hostname
 		if node.PublicIPv4 != "" && node.Host != "" && node.PrivateIPv4 != "" {
 			return nil


### PR DESCRIPTION
RHEL uses the full FQDN for `hostname`